### PR TITLE
feat: headless-first rewrite with automated release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,125 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    # Check for a new LTspice release every Monday 04:00 UTC
+    - cron: "0 4 * * 1"
+  workflow_dispatch:
+
+jobs:
+  # ── Check whether a new LTspice MSI is available ──────────────────────────
+  # Uses the ETag from a HEAD request as a content fingerprint.
+  # For push/workflow_dispatch we always proceed. For scheduled runs we only
+  # proceed if the ETag has changed since the last successful release.
+  check:
+    runs-on: ubuntu-latest
+    outputs:
+      should-release: ${{ steps.decide.outputs.value }}
+    steps:
+      - name: Fetch LTspice ETag
+        id: etag
+        run: |
+          ETAG=$(curl -sI https://ltspice.analog.com/software/LTspice64.msi \
+            | grep -i '^etag:' | awk '{print $2}' | tr -d '"\r\n')
+          echo "value=$ETAG" >> "$GITHUB_OUTPUT"
+
+      # Cache key is the ETag value. A hit means the MSI hasn't changed.
+      - name: Check ETag cache
+        id: cache
+        uses: actions/cache@v4
+        with:
+          path: .ltspice-etag-sentinel
+          key: ltspice-etag-${{ steps.etag.outputs.value }}
+
+      # Write the sentinel file so actions/cache saves it under the new key
+      - name: Update ETag sentinel
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: echo "${{ steps.etag.outputs.value }}" > .ltspice-etag-sentinel
+
+      - name: Decide whether to release
+        id: decide
+        run: |
+          # Always release on a direct push or manual trigger; for the weekly
+          # schedule only release if LTspice itself has been updated.
+          if [[ "${{ github.event_name }}" != "schedule" || \
+                "${{ steps.cache.outputs.cache-hit }}" != "true" ]]; then
+            echo "value=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=false" >> "$GITHUB_OUTPUT"
+            echo "LTspice MSI unchanged — skipping release."
+          fi
+
+  # ── Build, test, and publish ───────────────────────────────────────────────
+  release:
+    needs: check
+    if: needs.check.outputs.should-release == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set cache week key
+        run: echo "CACHE_WEEK=$(date -u +%Y-W%V)" >> "$GITHUB_ENV"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # ── 1. Build locally for testing ────────────────────────────────────────
+      - name: Build image (local)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          load: true
+          tags: docker-ltspice:ci
+          cache-from: type=gha,scope=ltspice-w${{ env.CACHE_WEEK }}
+          cache-to: type=gha,scope=ltspice-w${{ env.CACHE_WEEK }},mode=max
+
+      # ── 2. Run simulation tests ─────────────────────────────────────────────
+      - name: Run simulation tests
+        run: |
+          chmod +x test.sh
+          ./test.sh docker-ltspice:ci
+
+      - name: Upload simulation log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rc_filter_log
+          path: test/rc_filter.log
+          if-no-files-found: warn
+
+      # ── 3. Publish to Docker Hub (only if tests passed) ─────────────────────
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # Tags:
+      #   latest              – always the newest image
+      #   YYYY.MM.DD          – date of this build (overwritten if rebuilt same day)
+      #   YYYY.MM.DD-<sha>    – unique per commit; preserves same-day rebuilds
+      - name: Generate Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: aanas0sayed/docker-ltspice
+          tags: |
+            type=raw,value=latest
+            type=raw,value={{date 'YYYY.MM.DD'}}
+            type=raw,value={{date 'YYYY.MM.DD'}}-{{sha}}
+
+      - name: Build and push to Docker Hub
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # Read from the cache warmed by the test build — no need to re-write
+          cache-from: type=gha,scope=ltspice-w${{ env.CACHE_WEEK }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,9 +18,6 @@ jobs:
       - name: Set cache week key
         run: echo "CACHE_WEEK=$(date -u +%Y-W%V)" >> "$GITHUB_ENV"
 
-      - name: Set up QEMU (for linux/amd64 emulation if needed)
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,50 @@
+name: LTspice headless test
+
+on:
+  push:
+  pull_request:
+  schedule:
+    # Re-run weekly (Monday 03:00 UTC) to pick up new LTspice releases
+    - cron: "0 3 * * 1"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set cache week key
+        run: echo "CACHE_WEEK=$(date -u +%Y-W%V)" >> "$GITHUB_ENV"
+
+      - name: Set up QEMU (for linux/amd64 emulation if needed)
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          load: true
+          tags: docker-ltspice:ci
+          # Cache key includes the year+week so the weekly scheduled run gets a
+          # fresh cache scope and re-downloads LTspice if a new release is out.
+          cache-from: type=gha,scope=ltspice-w${{ env.CACHE_WEEK }}
+          cache-to: type=gha,scope=ltspice-w${{ env.CACHE_WEEK }},mode=max
+
+      - name: Run simulation test
+        run: |
+          chmod +x test.sh
+          ./test.sh docker-ltspice:ci
+
+      - name: Upload simulation log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rc_filter_log
+          path: test/rc_filter.log
+          if-no-files-found: warn

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,9 +4,6 @@ on:
   push:
   pull_request:
   workflow_dispatch:
-  schedule:
-    # Re-run weekly (Monday 03:00 UTC) to pick up new LTspice releases
-    - cron: "0 3 * * 1"
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,7 @@ name: LTspice headless test
 on:
   push:
   pull_request:
+  workflow_dispatch:
   schedule:
     # Re-run weekly (Monday 03:00 UTC) to pick up new LTspice releases
     - cron: "0 3 * * 1"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# LTspice simulation outputs
+test/*.log
+test/*.raw
+test/*.op.raw
+test/*.fft
+test/*.mout
+test/*.net.bak
+
+# macOS
+.DS_Store
+
+# Docker build artefacts
+*.tar

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ test/*.op.raw
 test/*.fft
 test/*.mout
 test/*.net.bak
+test/*.db
 
 # macOS
 .DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,14 +48,22 @@ RUN apt-get update \
 
 # ── 5. Wine env ────────────────────────────────────────────────────────────
 ENV WINEPREFIX=/root/.wine \
+    WINEDEBUG=-all \
     DISPLAY=:99
 
 # ── 6. Install LTspice ─────────────────────────────────────────────────────
 # Xvfb must be running before wineboot/msiexec – both need a display.
 # We start it in the same RUN layer, do everything, then kill it.
-RUN wget -q -O /tmp/LTspice64.msi https://ltspice.analog.com/software/LTspice64.msi \
+RUN Xvfb :99 -screen 0 1024x768x24 & \
+    sleep 2 \
+    && WINEDLLOVERRIDES="mscoree,mshtml=" wineboot --init \
+    && wineserver --wait \
+    && wget -q -O /tmp/LTspice64.msi https://ltspice.analog.com/software/LTspice64.msi \
     && wine msiexec /i /tmp/LTspice64.msi /quiet /norestart \
-    && rm /tmp/LTspice64.msi
+    && wineserver --wait \
+    && rm /tmp/LTspice64.msi \
+    && rm -rf /tmp/.wine-* /tmp/wine-* \
+    && kill %1 2>/dev/null || true
     
 # ── 7. Entrypoint ──────────────────────────────────────────────────────────
 COPY entrypoint.sh /usr/local/bin/entrypoint

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ RUN wget https://ltspice.analog.com/software/LTspice64.msi && \
     rm LTspice64.msi
 
 # Install a wrapper script so 'ltspice' works in any shell
-RUN printf '#!/bin/sh\nexec wine "/root/.wine/drive_c/Program Files/ADI/LTspice/LTspice.exe" "$@"\n' \
+RUN { echo '#!/bin/sh'; \
+      echo 'exec wine "/root/.wine/drive_c/Program Files/ADI/LTspice/LTspice.exe" "$@"'; } \
     > /usr/local/bin/ltspice && chmod +x /usr/local/bin/ltspice
 
 # Use the base image entrypoint (handles X11 forwarding and RDP server modes)

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,9 @@ RUN wget https://ltspice.analog.com/software/LTspice64.msi && \
     wine msiexec /i LTspice64.msi && \
     rm LTspice64.msi
 
-# Set up an alias for LTspice
-RUN echo "alias ltspice='wine \"/root/.wine/drive_c/Program Files/ADI/LTspice/Ltspice.exe\"'" >> ~/.bashrc
+# Install a wrapper script so 'ltspice' works in any shell
+RUN printf '#!/bin/sh\nexec wine "/root/.wine/drive_c/Program Files/ADI/LTspice/LTspice.exe" "$@"\n' \
+    > /usr/local/bin/ltspice && chmod +x /usr/local/bin/ltspice
 
 # Set bash as the entry point
 ENTRYPOINT ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM scottyhardy/docker-wine:latest
 
+# Install Xvfb for headless (batch) operation
+RUN apt-get update && apt-get install -y --no-install-recommends xvfb && rm -rf /var/lib/apt/lists/*
+
 # Download and install LTspice
 RUN wget https://ltspice.analog.com/software/LTspice64.msi && \
     wine msiexec /i LTspice64.msi && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN dpkg --add-architecture i386 \
 
 # ── 4. Wine ────────────────────────────────────────────────────────────────
 RUN apt-get update \
-    && apt-get install -y --install-recommends \
+    && apt-get install -y --no-install-recommends \
         winehq-${WINE_BRANCH} \
     && rm -rf /var/lib/apt/lists/*
 
@@ -54,6 +54,7 @@ ENV WINEPREFIX=/root/.wine \
 # ── 6. Install LTspice ─────────────────────────────────────────────────────
 # Xvfb must be running before wineboot/msiexec – both need a display.
 # We start it in the same RUN layer, do everything, then kill it.
+# wget and other build-only tools are removed at the end of this layer.
 RUN Xvfb :99 -screen 0 1024x768x24 & \
     sleep 2 \
     && WINEDLLOVERRIDES="mscoree,mshtml=" wineboot --init \
@@ -64,12 +65,16 @@ RUN Xvfb :99 -screen 0 1024x768x24 & \
     && rm /tmp/LTspice64.msi \
     && rm -rf /tmp/.wine-* /tmp/wine-* \
     && kill %1 2>/dev/null || true
-    
-# ── 7. Entrypoint ──────────────────────────────────────────────────────────
+
+# ── 7. Remove build-only tools ────────────────────────────────────────────
+RUN apt-get purge -y --auto-remove wget p7zip-full unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+# ── 8. Entrypoint ──────────────────────────────────────────────────────────
 COPY entrypoint.sh /usr/local/bin/entrypoint
 RUN chmod +x /usr/local/bin/entrypoint
 
-# ── 8. LTspice wrapper ─────────────────────────────────────────────────────
+# ── 9. LTspice wrapper ─────────────────────────────────────────────────────
 COPY wrappers/ltspice /usr/local/bin/ltspice
 RUN chmod +x /usr/local/bin/ltspice
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,69 @@
-FROM scottyhardy/docker-wine:latest
+# ─────────────────────────────────────────────────────────────────────────────
+# ltspice – single image: lean Wine base + LTspice install
+# Base: debian:bookworm-slim
+# ─────────────────────────────────────────────────────────────────────────────
 
-# Install Xvfb for headless (batch) operation
-RUN apt-get update && apt-get install -y --no-install-recommends xvfb && rm -rf /var/lib/apt/lists/*
+FROM debian:bookworm-slim
 
-# Download and install LTspice
-RUN wget https://ltspice.analog.com/software/LTspice64.msi && \
-    wine msiexec /i LTspice64.msi && \
-    rm LTspice64.msi
+ARG WINE_BRANCH=stable
+ARG DEBIAN_FRONTEND=noninteractive
 
-# Install a wrapper script so 'ltspice' works in any shell
-RUN { echo '#!/bin/sh'; \
-      echo 'exec wine "/root/.wine/drive_c/Program Files/ADI/LTspice/LTspice.exe" "$@"'; } \
-    > /usr/local/bin/ltspice && chmod +x /usr/local/bin/ltspice
+# ── 1. Core packages ───────────────────────────────────────────────────────
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        wget \
+        gnupg \
+        locales \
+        xvfb \
+        cabextract \
+        winbind \
+        gosu \
+        p7zip-full \
+        unzip \
+    && rm -rf /var/lib/apt/lists/*
 
-# Use the base image entrypoint (handles X11 forwarding and RDP server modes)
-ENTRYPOINT ["/usr/bin/entrypoint"]
+# ── 2. Locale ──────────────────────────────────────────────────────────────
+RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen
+ENV LANG=en_US.UTF-8 \
+    LANGUAGE=en_US:en \
+    LC_ALL=en_US.UTF-8
+
+# ── 3. WineHQ repo ─────────────────────────────────────────────────────────
+RUN dpkg --add-architecture i386 \
+    && mkdir -p /etc/apt/keyrings \
+    && wget -qO /etc/apt/keyrings/winehq.key \
+        https://dl.winehq.org/wine-builds/winehq.key \
+    && echo \
+        "deb [signed-by=/etc/apt/keyrings/winehq.key] \
+        https://dl.winehq.org/wine-builds/debian/ \
+        bookworm main" \
+        > /etc/apt/sources.list.d/winehq.list
+
+# ── 4. Wine ────────────────────────────────────────────────────────────────
+RUN apt-get update \
+    && apt-get install -y --install-recommends \
+        winehq-${WINE_BRANCH} \
+    && rm -rf /var/lib/apt/lists/*
+
+# ── 5. Wine env ────────────────────────────────────────────────────────────
+ENV WINEPREFIX=/root/.wine \
+    DISPLAY=:99
+
+# ── 6. Install LTspice ─────────────────────────────────────────────────────
+# Xvfb must be running before wineboot/msiexec – both need a display.
+# We start it in the same RUN layer, do everything, then kill it.
+RUN wget -q -O /tmp/LTspice64.msi https://ltspice.analog.com/software/LTspice64.msi \
+    && wine msiexec /i /tmp/LTspice64.msi /quiet /norestart \
+    && rm /tmp/LTspice64.msi
+    
+# ── 7. Entrypoint ──────────────────────────────────────────────────────────
+COPY entrypoint.sh /usr/local/bin/entrypoint
+RUN chmod +x /usr/local/bin/entrypoint
+
+# ── 8. LTspice wrapper ─────────────────────────────────────────────────────
+COPY wrappers/ltspice /usr/local/bin/ltspice
+RUN chmod +x /usr/local/bin/ltspice
+
+ENTRYPOINT ["/usr/local/bin/entrypoint"]
+CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,5 @@ RUN wget https://ltspice.analog.com/software/LTspice64.msi && \
 RUN printf '#!/bin/sh\nexec wine "/root/.wine/drive_c/Program Files/ADI/LTspice/LTspice.exe" "$@"\n' \
     > /usr/local/bin/ltspice && chmod +x /usr/local/bin/ltspice
 
-# Set bash as the entry point
-ENTRYPOINT ["/bin/bash"]
+# Use the base image entrypoint (handles X11 forwarding and RDP server modes)
+ENTRYPOINT ["/usr/bin/entrypoint"]

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Aanas Sayed
+Copyright (c) 2026 Aanas Sayed
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -6,15 +6,56 @@
 
 <!-- badges: end -->
 
-This Docker image provides an environment for running [LTspice](https://www.analog.com/en/resources/design-tools-and-calculators/ltspice-simulator.html), a popular electronic circuit simulation software, using Wine on a Linux image. It is based on the scottyhardy/docker-wine project and includes additional configurations specific to running LTspice.
 
-`aanas0sayed/docker-ltspice` is aimed for running LTspice for bulk simulations as part of pipelines. Headless operations will require Xvfb to be set up correctly. This is currently in the pipeline.
+**docker-ltspice** provides a fully headless, automated environment for running [LTspice](https://www.analog.com/en/resources/design-tools-and-calculators/ltspice-simulator.html) (Windows version) under Wine in Linux containers. It is designed for CI pipelines, batch simulation, and server use—no GUI or desktop required.
+
+**Key features:**
+- Runs LTspice in true headless mode (no desktop, no VNC, no RDP needed)
+- Handles all Wine/Xvfb quirks for you (see below)
+- Works out-of-the-box on Linux CI runners (e.g., GitHub Actions)
+- Includes a test harness for automated .meas validation
+
+**Known issue:**
+- On macOS, running with a real X11 display (e.g., by passing DISPLAY and using XQuartz) is not reliable—Wine/LTspice may hang or fail to start. Headless mode works and is the only supported configuration on macOS. On Linux, running with a real X11 display usually works, but is not the main focus.
 
 ## Pre-built images
 
 Images are available on [DockerHub](https://hub.docker.com/r/aanas0sayed/docker-ltspice).
 
-## Usage
+
+## Usage (Headless/Bulk Simulation)
+
+```bash
+docker run --rm -v "$PWD/test:/sim" aanas0sayed/docker-ltspice:latest
+```
+
+This will automatically:
+- Prime Wine/LTspice (workaround for Wine GUI service hangs)
+- Start Xvfb on :99
+- Run your simulation in /sim (see test.sh for an example)
+
+**Typical batch/test usage:**
+
+```bash
+docker run --rm -v "$PWD/test:/sim" aanas0sayed/docker-ltspice:latest /bin/bash -c '
+    wine "/root/.wine/drive_c/Program Files/ADI/LTspice/LTspice.exe" -b -run "Z:\\sim\\your_circuit.net"
+'
+```
+
+## Overriding Entrypoint (Advanced/GUI)
+
+If you want to run with a real X11 display, you can override the entrypoint and manage Xvfb/DISPLAY yourself:
+
+```bash
+docker run --rm -it --entrypoint /bin/bash -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix aanas0sayed/docker-ltspice
+# Now start Xvfb or connect to your X server, then run wine LTspice.exe ...
+```
+
+**Warning:** On macOS, if you try to use a real X11 display (e.g., by passing DISPLAY and using XQuartz), Wine/LTspice may hang or fail to start. This is a Wine/X11 limitation and not fixable in this image. Headless mode works. On Linux, running with a real X11 display usually works, but is not the main focus.
+
+## CI Example
+
+See [test.sh](test.sh) and [test.yml](.github/workflows/test.yml) for a full CI pipeline example that validates .meas results from a simulation log.
 
 ### Pull the Image
 
@@ -80,39 +121,21 @@ docker run -it --rm -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix --user=
 
 This command runs the container with the same username, UID, GID, and home path as your current user, allowing you to interact with files on the local file system without permissions issues.
 
-## Additional Options
 
-- Run with RDP server enabled (as root):
+## Known Issues
 
-    ```bash
-    docker run -it --rm -e RDP_SERVER=yes -p 3389:3389 aanas0sayed/docker-ltspice
-    ```
-
-- Run with RDP server enabled (as current user):
-
-    ```bash
-    docker run -it --rm -e RDP_SERVER=yes -p 3389:3389 -e USER_ID=$(id -u) -e GROUP_ID=$(id -g) aanas0sayed/docker-ltspice
-    ```
-
-For more options and detailed usage instructions on the base image, refer to the [scottyhardy/docker-wine](https://github.com/scottyhardy/docker-wine/blob/master/).
+- **macOS/XQuartz:** Headless mode is the only supported configuration. On macOS, running with XQuartz (by passing DISPLAY) is unreliable and may hang or fail to start.
+- **ARM/M-series Macs:** Use `--platform linux/amd64` when running on Apple Silicon.
 
 ## Troubleshooting
 
-- Test the display:
+- If your simulation hangs, make sure you are running in headless mode (do not set DISPLAY to a real X server).
+- If you want to debug interactively, override the entrypoint and start Xvfb manually as shown above.
 
-    ```bash
-    ltspice wine notepad
-    ```
-
-- Test the sound:
-
-    ```bash
-    ltspice pacat -vv /dev/urandom
-    ```
 
 ## Contributing
 
-If you find any issues or have suggestions for improvements, please contribute by creating a GitHub issue or submitting a pull request.
+Issues and PRs are welcome! Please file bugs or suggestions on GitHub.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,142 +1,98 @@
 # docker-ltspice
 
 <!-- badges: start -->
-
 [![license](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-
 <!-- badges: end -->
 
+Run [LTspice](https://www.analog.com/en/resources/design-tools-and-calculators/ltspice-simulator.html) headlessly in Docker via Wine. Designed for batch simulation, CI pipelines, and server use—no desktop required.
 
-**docker-ltspice** provides a fully headless, automated environment for running [LTspice](https://www.analog.com/en/resources/design-tools-and-calculators/ltspice-simulator.html) (Windows version) under Wine in Linux containers. It is designed for CI pipelines, batch simulation, and server use—no GUI or desktop required.
+The image is based on `debian:bookworm-slim` with Wine (stable) and LTspice pre-installed. The entrypoint automatically handles Wine initialisation and starts Xvfb on `:99`, so simulations work out of the box.
 
-**Key features:**
-- Runs LTspice in true headless mode (no desktop, no VNC, no RDP needed)
-- Handles all Wine/Xvfb quirks for you (see below)
-- Works out-of-the-box on Linux CI runners (e.g., GitHub Actions)
-- Includes a test harness for automated .meas validation
-
-**Known issue:**
-- On macOS, running with a real X11 display (e.g., by passing DISPLAY and using XQuartz) is not reliable—Wine/LTspice may hang or fail to start. Headless mode works and is the only supported configuration on macOS. On Linux, running with a real X11 display usually works, but is not the main focus.
-
-## Pre-built images
-
-Images are available on [DockerHub](https://hub.docker.com/r/aanas0sayed/docker-ltspice).
-
-
-## Usage (Headless/Bulk Simulation)
-
-```bash
-docker run --rm -v "$PWD/test:/sim" aanas0sayed/docker-ltspice:latest
-```
-
-This will automatically:
-- Prime Wine/LTspice (workaround for Wine GUI service hangs)
-- Start Xvfb on :99
-- Run your simulation in /sim (see test.sh for an example)
-
-**Typical batch/test usage:**
-
-```bash
-docker run --rm -v "$PWD/test:/sim" aanas0sayed/docker-ltspice:latest /bin/bash -c '
-    wine "/root/.wine/drive_c/Program Files/ADI/LTspice/LTspice.exe" -b -run "Z:\\sim\\your_circuit.net"
-'
-```
-
-## Overriding Entrypoint (Advanced/GUI)
-
-If you want to run with a real X11 display, you can override the entrypoint and manage Xvfb/DISPLAY yourself:
-
-```bash
-docker run --rm -it --entrypoint /bin/bash -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix aanas0sayed/docker-ltspice
-# Now start Xvfb or connect to your X server, then run wine LTspice.exe ...
-```
-
-**Warning:** On macOS, if you try to use a real X11 display (e.g., by passing DISPLAY and using XQuartz), Wine/LTspice may hang or fail to start. This is a Wine/X11 limitation and not fixable in this image. Headless mode works. On Linux, running with a real X11 display usually works, but is not the main focus.
-
-## CI Example
-
-See [test.sh](test.sh) and [test.yml](.github/workflows/test.yml) for a full CI pipeline example that validates .meas results from a simulation log.
-
-### Pull the Image
-
-```bash
-docker pull aanas0sayed/docker-ltspice
-```
-
-### Running the Container
+Pre-built images are available on [DockerHub](https://hub.docker.com/r/aanas0sayed/docker-ltspice).
 
 > [!IMPORTANT]
->
-> The base image is `linux/amd64` and will not work on a machine running with a `arm64` architecture unless `--platform linux/amd64` is added to the `docker run` command.
+> The image is `linux/amd64` only. On ARM machines (e.g. Apple Silicon), add `--platform linux/amd64` to all `docker run` commands.
 
-#### Running on Linux/Windows
+---
+
+## Headless usage
+
+Mount a directory containing your netlist and run LTspice in batch mode:
 
 ```bash
-docker run -it --rm -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix aanas0sayed/docker-ltspice
+docker run --rm \
+  -v /path/to/netlists:/sim \
+  aanas0sayed/docker-ltspice \
+  ltspice -b -run "Z:\\sim\\your_circuit.net"
 ```
 
-#### Running on Mac
+The `ltspice` command is a thin wrapper around `wine LTspice.exe`.
 
-1. Install [XQuartz](https://www.xquartz.org):
+### CI example
+
+See [test.sh](test.sh) and [.github/workflows/test.yml](.github/workflows/test.yml) for a working example that runs a simulation and validates `.meas` results from the output log.
+
+---
+
+## X11 forwarding (GUI mode)
+
+### Linux
+
+```bash
+docker run --rm -it \
+  -e DISPLAY=$DISPLAY \
+  -v /tmp/.X11-unix:/tmp/.X11-unix \
+  aanas0sayed/docker-ltspice
+```
+
+### macOS (XQuartz)
+
+1. Install XQuartz:
 
     ```bash
     brew install --cask xquartz
     ```
 
-2. Logout and login of your Mac to activate XQuartz as the default X11 server.
-
-3. Start [XQuartz](https://www.xquartz.org):
+2. Enable TCP listening (XQuartz disables this by default) and restart:
 
     ```bash
-    open -a XQuartz
+    defaults write org.xquartz.X11 nolisten_tcp -bool false
+    killall XQuartz 2>/dev/null; open -a XQuartz
     ```
 
-4. Enable "Allow connections from network clients" in Security Settings.
-5. Restart your Mac and start XQuartz again:
+3. Allow connections from localhost:
 
     ```bash
-    open -a XQuartz
+    DISPLAY=:0 xhost +127.0.0.1
     ```
 
-> [!NOTE]
->
-> If connecting to a remote server, the access control will need to be modified. Running `xhost +` allows any client to connect (not recommended). If you have security concerns you can append an IP address for a whitelist mechanism. Alternatively, if you want to limit X11 forwarding to local containers, you can limit clients to localhost only via `xhost +localhost`
-> This is not a persistent setting.
-
-6. Run the container:
+4. Run the container:
 
     ```bash
-    docker run -it --rm -e DISPLAY=docker.for.mac.host.internal:0 -v /tmp/.X11-unix:/tmp/.X11-unix aanas0sayed/docker-ltspice
+    docker run --rm -it \
+      --platform linux/amd64 \
+      -e DISPLAY=host.docker.internal:0 \
+      -v /tmp/.X11-unix:/tmp/.X11-unix \
+      aanas0sayed/docker-ltspice
     ```
 
-For MacBook M series (ARM chip), add `--platform linux/amd64` to the command.
-
-For support on this topic, please check the guide on [X11 forwarding on macOS and docker](https://gist.github.com/sorny/969fe55d85c9b0035b0109a31cbcb088) 
-
-### Running as Current User
-
-```bash
-docker run -it --rm -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix --user=$(id -u):$(id -g) aanas0sayed/docker-ltspice
-```
-
-This command runs the container with the same username, UID, GID, and home path as your current user, allowing you to interact with files on the local file system without permissions issues.
-
-
-## Known Issues
-
-- **macOS/XQuartz:** Headless mode is the only supported configuration. On macOS, running with XQuartz (by passing DISPLAY) is unreliable and may hang or fail to start.
-- **ARM/M-series Macs:** Use `--platform linux/amd64` when running on Apple Silicon.
+---
 
 ## Troubleshooting
 
-- If your simulation hangs, make sure you are running in headless mode (do not set DISPLAY to a real X server).
-- If you want to debug interactively, override the entrypoint and start Xvfb manually as shown above.
+- **File not found / path errors:** LTspice runs inside Wine, so paths must use the Wine `Z:` drive (which maps to `/` on the container). For example, a netlist mounted at `/sim/circuit.net` should be passed as `Z:\\sim\\circuit.net`.
+- **Interactive shell:** The entrypoint still runs (priming Wine and starting Xvfb) before handing off to your command:
 
+    ```bash
+    docker run --rm -it aanas0sayed/docker-ltspice /bin/bash
+    ```
+
+---
 
 ## Contributing
 
-Issues and PRs are welcome! Please file bugs or suggestions on GitHub.
+Issues and pull requests are welcome.
 
 ## License
 
-This project is licensed under the [MIT License](https://opensource.org/license/MIT). For more details, please refer to the LICENSE file.
+[MIT License](https://opensource.org/license/MIT) — see [LICENSE](LICENSE) for details.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# entrypoint.sh – runs before every command inside the container
+#
+# Responsibilities (mirrors what scottyhardy's entrypoint.sh does):
+#   1. Start Xvfb on DISPLAY :99 so Wine has a virtual screen to render into
+#   2. Wait until the X server is actually accepting connections
+#   3. First-run: initialise WINEPREFIX (creates the fake C: drive)
+#   4. exec the user's command (bash by default, or anything passed to docker run)
+
+set -e
+
+# ── 1. Start Xvfb if not already running ───────────────────────────────────
+XVFB_DISPLAY="${DISPLAY:-:99}"
+XVFB_RESOLUTION="${XVFB_RESOLUTION:-1024x768x24}"
+
+if ! pgrep -x Xvfb > /dev/null 2>&1; then
+    echo "[entrypoint] Starting Xvfb on ${XVFB_DISPLAY} (${XVFB_RESOLUTION})"
+    Xvfb "${XVFB_DISPLAY}" -screen 0 "${XVFB_RESOLUTION}" -nolisten tcp &
+    XVFB_PID=$!
+
+    # ── 2. Wait for the X server to be ready (max 10 s) ────────────────────
+    for i in $(seq 1 20); do
+        if xdpyinfo -display "${XVFB_DISPLAY}" > /dev/null 2>&1; then
+            echo "[entrypoint] Xvfb ready."
+            break
+        fi
+        sleep 0.5
+    done
+fi
+
+export DISPLAY="${XVFB_DISPLAY}"
+
+# ── 3. Initialise Wine prefix on first run ─────────────────────────────────
+#   wineboot --init creates ~/.wine (WINEPREFIX) and runs the initial Wine
+#   setup. We suppress the GUI and set WINEDLLOVERRIDES to skip the Mono/
+#   Gecko install dialogs that would otherwise block forever in a headless env.
+# if [ ! -f "${WINEPREFIX}/system.reg" ]; then
+#     echo "[entrypoint] Initialising Wine prefix at ${WINEPREFIX} …"
+#     WINEDLLOVERRIDES="mscoree,mshtml=" \
+#     DISPLAY="${XVFB_DISPLAY}" \
+#     wineboot --init 2>/dev/null
+#     # Wait for wineserver to finish (important before running any wine command)
+#     wineserver --wait
+#     echo "[entrypoint] Wine prefix ready."
+# fi
+
+# ── 4. Hand off to the user's command ──────────────────────────────────────
+exec "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,40 +9,42 @@
 
 set -e
 
-# ── 1. Start Xvfb if not already running ───────────────────────────────────
 XVFB_DISPLAY="${DISPLAY:-:99}"
-XVFB_RESOLUTION="${XVFB_RESOLUTION:-1024x768x24}"
+DISPLAY_NUM="${XVFB_DISPLAY#:}"
+XVFB_RESOLUTION="${XVFB_RESOLUTION:-1024x768x16}"
 
-if ! pgrep -x Xvfb > /dev/null 2>&1; then
-    echo "[entrypoint] Starting Xvfb on ${XVFB_DISPLAY} (${XVFB_RESOLUTION})"
-    Xvfb "${XVFB_DISPLAY}" -screen 0 "${XVFB_RESOLUTION}" -nolisten tcp &
-    XVFB_PID=$!
+# ── 1. Prime Wine (no X server yet) ───────────────────────────────────────
+#   The first wine invocation after a fresh container start triggers internal
+#   service/init work (winebth, shell32, etc.).  If an X server IS available,
+#   those services try to create windows and block forever.  Running LTspice
+#   once with DISPLAY pointing to a non-existent server makes them fail fast
+#   and complete their init.  The second run then works cleanly.
+echo "[entrypoint] Priming Wine (display ${XVFB_DISPLAY}, no X yet)..."
+export DISPLAY="${XVFB_DISPLAY}"
+wine "/root/.wine/drive_c/Program Files/ADI/LTspice/LTspice.exe" -b 2>/dev/null || true
+wineserver --wait 2>/dev/null || true
+echo "[entrypoint] Wine primed."
 
-    # ── 2. Wait for the X server to be ready (max 10 s) ────────────────────
-    for i in $(seq 1 20); do
-        if xdpyinfo -display "${XVFB_DISPLAY}" > /dev/null 2>&1; then
-            echo "[entrypoint] Xvfb ready."
-            break
-        fi
-        sleep 0.5
-    done
-fi
+# ── 2. Start Xvfb ─────────────────────────────────────────────────────────
+rm -f "/tmp/.X${DISPLAY_NUM}-lock" "/tmp/.X11-unix/X${DISPLAY_NUM}"
+echo "[entrypoint] Starting Xvfb on ${XVFB_DISPLAY} (${XVFB_RESOLUTION})"
+Xvfb "${XVFB_DISPLAY}" -screen 0 "${XVFB_RESOLUTION}" -nolisten tcp 2>/dev/null &
+XVFB_PID=$!
+
+# Wait for the X server socket to appear (max 10 s)
+for i in $(seq 1 20); do
+    if [ -e "/tmp/.X11-unix/X${DISPLAY_NUM}" ]; then
+        echo "[entrypoint] Xvfb ready (PID ${XVFB_PID})."
+        break
+    fi
+    if ! kill -0 "$XVFB_PID" 2>/dev/null; then
+        echo "[entrypoint] ERROR: Xvfb exited unexpectedly!" >&2
+        break
+    fi
+    sleep 0.5
+done
 
 export DISPLAY="${XVFB_DISPLAY}"
 
-# ── 3. Initialise Wine prefix on first run ─────────────────────────────────
-#   wineboot --init creates ~/.wine (WINEPREFIX) and runs the initial Wine
-#   setup. We suppress the GUI and set WINEDLLOVERRIDES to skip the Mono/
-#   Gecko install dialogs that would otherwise block forever in a headless env.
-# if [ ! -f "${WINEPREFIX}/system.reg" ]; then
-#     echo "[entrypoint] Initialising Wine prefix at ${WINEPREFIX} …"
-#     WINEDLLOVERRIDES="mscoree,mshtml=" \
-#     DISPLAY="${XVFB_DISPLAY}" \
-#     wineboot --init 2>/dev/null
-#     # Wait for wineserver to finish (important before running any wine command)
-#     wineserver --wait
-#     echo "[entrypoint] Wine prefix ready."
-# fi
-
-# ── 4. Hand off to the user's command ──────────────────────────────────────
+# ── 3. Hand off to the user's command ──────────────────────────────────────
 exec "$@"

--- a/test.sh
+++ b/test.sh
@@ -22,22 +22,15 @@ echo "    image  : $IMAGE"
 echo "    netlist: $TEST_DIR/$NETLIST"
 echo ""
 
+# ── Clean up previous run artifacts ──────────────────────────────────────────
+rm -f "$TEST_DIR"/"${NETLIST%.net}".{log,raw,op.raw,db}
+
 # ── Run LTspice inside the container ─────────────────────────────────────────
 # Wine maps Z:\ to the Linux root, so /sim inside the container becomes Z:\sim
 docker run --rm \
     --volume "$TEST_DIR:/sim" \
-    "$IMAGE" -c '
+    "$IMAGE" /bin/bash -c '
 set -e
-
-# LTspice requires a display even in batch mode; start a virtual framebuffer
-Xvfb :0 -screen 0 1024x768x16 &
-XVFB_PID=$!
-export DISPLAY=:0
-
-# # Suppress Wine fixme/stub noise; keep only genuine errors (err channel)
-# export WINEDEBUG=-all,+err
-# # Silence the Bluetooth and network stub errors that always fire in containers
-# export WINEDLLOVERRIDES="winebth.sys="
     
 NETLIST_WIN="Z:\\sim\\rc_filter.net"
 LOG_WIN="/sim/rc_filter.log"
@@ -59,7 +52,6 @@ done
 kill "$WINE_PID" 2>/dev/null || true
 pkill -f wineserver 2>/dev/null || true
 
-kill "$XVFB_PID" 2>/dev/null || true
 echo "  [done] simulation finished"
 '
 

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# test.sh – run an LTspice batch simulation inside Docker and validate results.
+#
+# Usage: ./test.sh [image]
+#   image  Docker image to test (default: aanas0sayed/docker-ltspice)
+#
+# Exit codes:
+#   0  all .meas checks passed
+#   1  simulation failed or a measurement was not found in the log
+
+set -euo pipefail
+
+IMAGE="${1:-aanas0sayed/docker-ltspice}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEST_DIR="$SCRIPT_DIR/test"
+NETLIST="rc_filter.net"
+LOG="${NETLIST%.net}.log"
+LOG_PATH="$TEST_DIR/$LOG"
+
+echo "==> LTspice headless batch test"
+echo "    image  : $IMAGE"
+echo "    netlist: $TEST_DIR/$NETLIST"
+echo ""
+
+# ── Run LTspice inside the container ─────────────────────────────────────────
+# Wine maps Z:\ to the Linux root, so /sim inside the container becomes Z:\sim
+docker run --rm \
+    --platform=linux/amd64 \
+    --entrypoint bash \
+    --volume "$TEST_DIR:/sim" \
+    "$IMAGE" -c '
+set -e
+
+echo "  [xvfb] starting virtual display..."
+Xvfb :99 -screen 0 1024x768x24 -nolisten tcp &
+XVFB_PID=$!
+export DISPLAY=:99
+sleep 1
+
+NETLIST_WIN="Z:\\sim\\rc_filter.net"
+
+echo "  [run]  ltspice -b \"$NETLIST_WIN\""
+ltspice -Run -b "$NETLIST_WIN"
+
+# Allow Wine/LTspice to finish flushing the .log output file
+sleep 3
+
+kill "$XVFB_PID" 2>/dev/null || true
+echo "  [done] simulation finished"
+'
+
+# ── Check log was produced ────────────────────────────────────────────────────
+if [[ ! -f "$LOG_PATH" ]]; then
+    echo "FAIL: log file was not created at $LOG_PATH"
+    exit 1
+fi
+
+echo ""
+echo "==> Simulation log ($LOG):"
+echo "------------------------------------------------------------"
+cat "$LOG_PATH"
+echo "------------------------------------------------------------"
+
+# ── Validate .meas results ────────────────────────────────────────────────────
+echo ""
+echo "==> Validating .meas results..."
+
+PASS=1
+
+# Extract the numeric value from a .meas log line, e.g.:
+#   vout_max: MAX(v(out))=4.96832 FROM 0 TO 0.005  →  4.96832
+meas_value() {
+    grep -i "^${1}" "$LOG_PATH" 2>/dev/null | head -n1 | grep -oE '=[0-9eE.+-]+' | head -n1 | tr -d '='
+}
+
+check_meas_range() {
+    local name="$1" lo="$2" hi="$3"
+    local line val
+    line=$(grep -i "^${name}" "$LOG_PATH" 2>/dev/null | head -n1)
+    if [[ -z "$line" ]]; then
+        echo "  FAIL  '${name}' not found in log"
+        PASS=0
+        return
+    fi
+    if echo "$line" | grep -qi "FAIL"; then
+        echo "  FAIL  $line"
+        PASS=0
+        return
+    fi
+    # WHEN measurements format: "name: expr=threshold AT time"
+    # Standard format:          "name: EXPR=value FROM ..."
+    if echo "$line" | grep -qi " AT "; then
+        val=$(echo "$line" | grep -oiE 'AT [0-9eE.+-]+' | head -n1 | awk '{print $2}')
+    else
+        val=$(echo "$line" | grep -oE '=[0-9eE.+-]+' | head -n1 | tr -d '=')
+    fi
+    # Use awk for float comparison
+    if awk -v v="$val" -v lo="$lo" -v hi="$hi" 'BEGIN{exit !(v>=lo && v<=hi)}'; then
+        printf "  PASS  %-14s = %s  (expected [%s, %s])\n" "$name" "$val" "$lo" "$hi"
+    else
+        printf "  FAIL  %-14s = %s  (expected [%s, %s])\n" "$name" "$val" "$lo" "$hi"
+        PASS=0
+    fi
+}
+
+# V(out) max: 5·(1−e⁻⁵) ≈ 4.966 V — accept 4.9 to 5.0
+check_meas_range "vout_max"  4.9   5.0
+# Steady-state average (last 1 ms): > 4.9 V
+check_meas_range "vout_ss"   4.9   5.0
+# τ crossing time ≈ 1 ms — accept 0.9 ms to 1.1 ms
+check_meas_range "tau_rise"  0.0009  0.0011
+
+echo ""
+if [[ "$PASS" -eq 1 ]]; then
+    echo "==> All checks PASSED."
+else
+    echo "==> Test FAILED – one or more .meas values out of range."
+    exit 1
+fi

--- a/test.sh
+++ b/test.sh
@@ -32,18 +32,27 @@ docker run --rm \
 set -e
 
 echo "  [xvfb] starting virtual display..."
-Xvfb :99 -screen 0 1024x768x24 -nolisten tcp &
+# Redirect stderr to suppress harmless xkbcomp keysym warnings
+Xvfb :99 -screen 0 1024x768x24 -nolisten tcp 2>/dev/null &
 XVFB_PID=$!
 export DISPLAY=:99
 sleep 1
 
+# Suppress Wine fixme/stub noise; keep only genuine errors (err channel)
+export WINEDEBUG=-all,+err
+# Silence the Bluetooth and network stub errors that always fire in containers
+export WINEDLLOVERRIDES="winebth.sys="
+
 NETLIST_WIN="Z:\\sim\\rc_filter.net"
 
 echo "  [run]  ltspice -b \"$NETLIST_WIN\""
-ltspice -Run -b "$NETLIST_WIN"
+# Wine's wineserver keeps running after LTspice exits; timeout + wineserver -k
+# ensures we never hang. 60 s is far more than enough for a tiny netlist.
+timeout 60 ltspice -Run -b "$NETLIST_WIN" || true
+wineserver -k 2>/dev/null || true
 
-# Allow Wine/LTspice to finish flushing the .log output file
-sleep 3
+# Allow the .log file to be flushed to the volume mount
+sleep 1
 
 kill "$XVFB_PID" 2>/dev/null || true
 echo "  [done] simulation finished"

--- a/test.sh
+++ b/test.sh
@@ -25,31 +25,39 @@ echo ""
 # ── Run LTspice inside the container ─────────────────────────────────────────
 # Wine maps Z:\ to the Linux root, so /sim inside the container becomes Z:\sim
 docker run --rm \
-    --platform=linux/amd64 \
-    --entrypoint bash \
     --volume "$TEST_DIR:/sim" \
     "$IMAGE" -c '
 set -e
 
-echo "  [xvfb] starting virtual display..."
-# Redirect stderr to suppress harmless xkbcomp keysym warnings
-Xvfb :99 -screen 0 1024x768x24 -nolisten tcp 2>/dev/null &
+# LTspice requires a display even in batch mode; start a virtual framebuffer
+Xvfb :0 -screen 0 1024x768x16 &
 XVFB_PID=$!
-export DISPLAY=:99
-sleep 1
+export DISPLAY=:0
 
-# Suppress Wine fixme/stub noise; keep only genuine errors (err channel)
-export WINEDEBUG=-all,+err
-# Silence the Bluetooth and network stub errors that always fire in containers
-export WINEDLLOVERRIDES="winebth.sys="
-
+# # Suppress Wine fixme/stub noise; keep only genuine errors (err channel)
+# export WINEDEBUG=-all,+err
+# # Silence the Bluetooth and network stub errors that always fire in containers
+# export WINEDLLOVERRIDES="winebth.sys="
+    
 NETLIST_WIN="Z:\\sim\\rc_filter.net"
+LOG_WIN="/sim/rc_filter.log"
 
 echo "  [run]  ltspice -b \"$NETLIST_WIN\""
-ltspice -Run -b "$NETLIST_WIN"
+wine "/root/.wine/drive_c/Program Files/ADI/LTspice/LTspice.exe" -b -run "$NETLIST_WIN" &
+WINE_PID=$!
 
-# Allow Wine/LTspice to finish flushing the .log output file
-sleep 3
+# Poll for the log file to appear (LTspice writes it when done), max 90s
+for i in $(seq 1 90); do
+    if [[ -f "$LOG_WIN" ]]; then
+        sleep 1  # let LTspice finish flushing
+        break
+    fi
+    sleep 1
+done
+
+# Kill wine and wineserver now that we have the log
+kill "$WINE_PID" 2>/dev/null || true
+pkill -f wineserver 2>/dev/null || true
 
 kill "$XVFB_PID" 2>/dev/null || true
 echo "  [done] simulation finished"

--- a/test.sh
+++ b/test.sh
@@ -46,13 +46,10 @@ export WINEDLLOVERRIDES="winebth.sys="
 NETLIST_WIN="Z:\\sim\\rc_filter.net"
 
 echo "  [run]  ltspice -b \"$NETLIST_WIN\""
-# Wine's wineserver keeps running after LTspice exits; timeout + wineserver -k
-# ensures we never hang. 60 s is far more than enough for a tiny netlist.
-timeout 60 ltspice -Run -b "$NETLIST_WIN" || true
-wineserver -k 2>/dev/null || true
+ltspice -Run -b "$NETLIST_WIN"
 
-# Allow the .log file to be flushed to the volume mount
-sleep 1
+# Allow Wine/LTspice to finish flushing the .log output file
+sleep 3
 
 kill "$XVFB_PID" 2>/dev/null || true
 echo "  [done] simulation finished"

--- a/test/rc_filter.net
+++ b/test/rc_filter.net
@@ -1,0 +1,30 @@
+* RC Low-pass Filter – LTspice Headless Batch Test
+* -------------------------------------------------------
+* Simple RC circuit driven by a 0→5 V step.
+* RC time constant τ = R1·C1 = 1 kΩ · 1 µF = 1 ms
+*
+* After 5 ms (≥5τ) the capacitor should be fully charged:
+*   V(out) → 5 V
+*
+* .meas statements written to the .log file are checked by
+* test.sh to confirm the simulation ran correctly.
+
+* Step: 0 V → 5 V at t=0, stays high for the entire transient
+V1  in  0  PWL(0 0 1n 5)
+R1  in  out  1k
+C1  out  0   1u
+
+.tran 0.1u 5m
+
+* Max voltage seen at the output – expect ≈4.97 V (5·(1−e⁻⁵))
+.meas tran vout_max  MAX  V(out)
+
+* Average voltage over the last millisecond – expect >4.9 V
+.meas tran vout_ss   AVG  V(out)  FROM=4m  TO=5m
+
+* Time at which V(out) first crosses one τ voltage: 5·(1−e⁻¹) ≈ 3.161 V
+* Expect ≈1 ms
+.meas tran tau_rise  WHEN V(out)=3.161  RISE=1
+
+.backanno
+.end

--- a/wrappers/ltspice
+++ b/wrappers/ltspice
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exec wine "/root/.wine/drive_c/Program Files/ADI/LTspice/LTspice.exe" "$@"


### PR DESCRIPTION
## Summary

- Migrate Dockerfile to debian:bookworm-slim + winehq-stable (no-install-recommends)
- Add entrypoint.sh with Wine priming + Xvfb startup for reliable headless operation
- Add ltspice wrapper script (/usr/local/bin/ltspice)
- Add test workflow (test.yml) with simulation validation and artifact upload
- Add release workflow (release.yml) with ETag-based LTspice change detection, YYYY.MM.DD / YYYY.MM.DD-`<sha>` / latest tagging, and Docker Hub push
- Reduced image content size
- Rewrite README for headless-first usage with X11 forwarding docs for Linux/macOS